### PR TITLE
Hotfix/3.4.2

### DIFF
--- a/bot.go
+++ b/bot.go
@@ -89,7 +89,7 @@ func main() {
 	dg.AddHandler(messageReactionAdd)
 	dg.AddHandler(messageReactionRemove)
 
-	commandhandler = &commands.CommandHandler{make(map[string]commands.Command)}
+	commandhandler = &commands.CommandHandler{Commands: make(map[string]commands.Command)}
 
 	commandhandler.AddCommand("ping", &commands.Ping{})
 	commandhandler.AddCommand("setgame", &commands.SetGame{})
@@ -197,13 +197,13 @@ func messageCreate(s *discordgo.Session, m *discordgo.MessageCreate) {
 		args = args[1:]
 		channel, err := s.State.Channel(m.ChannelID)
 		if err != nil {
-			channel, err = s.State.PrivateChannel(m.ChannelID)
-			ctx = &commands.Context{conf, invoked, args, channel, nil, m, s}
+			channel, _ = s.State.PrivateChannel(m.ChannelID)
+			ctx = &commands.Context{Conf: conf, Invoked: invoked, Args: args, Channel: channel, Guild: nil, Mess: m, Sess: s}
 		} else {
 			guild, _ := s.State.Guild(channel.GuildID)
-			ctx = &commands.Context{conf, invoked, args, channel, guild, m, s}
+			ctx = &commands.Context{Conf: conf, Invoked: invoked, Args: args, Channel: channel, Guild: guild, Mess: m, Sess: s}
 		}
-		p, err := s.UserChannelPermissions(s.State.User.ID, m.ChannelID)
+		p, _ := s.UserChannelPermissions(s.State.User.ID, m.ChannelID)
 		if channel.Recipient == nil {
 			if p&discordgo.PermissionEmbedLinks != discordgo.PermissionEmbedLinks {
 				s.ChannelMessageDelete(m.ChannelID, m.ID)

--- a/bot.go
+++ b/bot.go
@@ -138,7 +138,7 @@ func messageReactionAdd(s *discordgo.Session, m *discordgo.MessageReactionAdd) {
 func messageReactionRemove(s *discordgo.Session, m *discordgo.MessageReactionRemove) {
 	if conf.LogMode {
 		timestamp := time.Now().UTC()
-		LogMessageNoAuthor(s, timestamp, m.UserID, m.MessageID, m.ChannelID, "REA", m.Emoji.Name, m.Emoji.APIName())
+		LogMessageNoAuthor(s, timestamp, m.UserID, m.MessageID, m.ChannelID, "RED", m.Emoji.Name, m.Emoji.APIName())
 	}
 }
 

--- a/log.go
+++ b/log.go
@@ -18,7 +18,7 @@ const (
 	BufferMax int = 65536
 )
 
-var logbuffers map[string]map[string]*bytes.Buffer = make(map[string]map[string]*bytes.Buffer)
+var logbuffers = make(map[string]map[string]*bytes.Buffer)
 var logmintime time.Time
 var logmaxtime time.Time
 

--- a/log.go
+++ b/log.go
@@ -55,7 +55,7 @@ func SendToBuffer(s *discordgo.Session, ChannelID, str string) {
 		logbuffer.WriteString(str)
 	} else {
 		logbuffer.WriteString(str)
-		if logbuffer.Len() >= logbuffer.Cap() {
+		if logbuffer.Len() >= logbuffer.Cap()-2200 {
 			f, err := GetLogFile(s, gn, cn)
 			logerror(err)
 			if conf.LogModeCompression {
@@ -87,6 +87,9 @@ func BufferLoop(s *discordgo.Session) {
 		if time.Now().After(logmaxtime) {
 			for k, v := range logbuffers {
 				for c, buf := range v {
+					if buf.Len() == 0 {
+						continue
+					}
 					f, err := GetLogFile(s, k, c)
 					logerror(err)
 					if conf.LogModeCompression {


### PR DESCRIPTION
- fix: buffer sizing, buffer flushing

    When doing periodic check, do not write to files, if there is nothing to write.
    Saves IO and when compression is enabled.
    Does not waste space and does not increase fragmentation by writing empty gzip frames (members).
- fix: code style sins
- fix: typo of log format key
